### PR TITLE
Add extension.toml

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,11 @@
+name = "Assembly Syntax"
+version = "0.0.2"
+authors = ["Jacob Parker <blocckba5her@gmail.com>"]
+description = "Generic Syntax Highlighting for Assembly"
+repository = "https://github.com/DevBlocky/zed-asm"
+id = "assembly-syntax"
+schema_version = 1
+grammar = "asm"
+[grammars.asm]
+repository = "https://github.com/RubixDev/tree-sitter-asm"
+commit = "6ace266be7ad6bf486a95427ca3fc949aff66211"


### PR DESCRIPTION
This PR adds 'extension.toml' file, converting from the existing 'extension.json' configuration.
    See https://github.com/zed-industries/extensions/issues/2104

    This change was generated automatically and needs to be manually tested.
    Bot script: https://github.com/sigmaSd/botfixzed/blob/master/bot.ts
    