### PR TITLE
Update repo to use new spec `extension.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-experiment.asm

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Zed Assembly Syntax
 
-Extension for [Zed](https://zed.dev) that adds assembly syntax highlighting
+Extension for [Zed](https://zed.dev) that adds assembly syntax highlighting.

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,0 @@
-{
-  "name": "Assembly Syntax",
-  "version": "0.0.1",
-  "authors": ["Jacob Parker <blocckba5her@gmail.com>"],
-  "description": "Generic Syntax Highlighting for Assembly",
-  "repository": "https://github.com/DevBlocky/zed-asm"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/o-x-e-y/zed-asm"
 
 [grammars.asm]
 repository = "https://github.com/RubixDev/tree-sitter-asm"
-commit = "04962e15f6b464cf1d75eada59506dc25090e186"
+commit = "6ace266be7ad6bf486a95427ca3fc949aff66211"

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,11 @@
+id = "zed-asm"
+name = "Assembly"
+description = "Generic Syntax Highlighting for Assembly"
+version = "0.0.2"
+schema_version = 1
+authors = ["Jacob Parker <blocckba5her@gmail.com>", "Oxey <lucoerlemans37@gmail.com>"]
+repository = "https://github.com/o-x-e-y/zed-asm"
+
+[grammars.asm]
+repository = "https://github.com/RubixDev/tree-sitter-asm"
+commit = "04962e15f6b464cf1d75eada59506dc25090e186"

--- a/grammars/asm.toml
+++ b/grammars/asm.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/RubixDev/tree-sitter-asm"
-commit = "6ace266be7ad6bf486a95427ca3fc949aff66211"


### PR DESCRIPTION
This repo works perfectly fine with regular Zed, but I ran into issues trying to get it to work with NixOS. The registry that is used for zed extensions ([nix-zed-extensions](https://github.com/DuskSystems/nix-zed-extensions)) can't parse the old formats so new ones are needed. This update shouldn't break anything with regular use since all it does is move to a new spec.
